### PR TITLE
Honour preset destination directory environment variables in `Makefile`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
-PREFIX=/usr
-EPREFIX=
-BINDIR=$(PREFIX)/bin
-DATADIR=$(PREFIX)/share/push
+PREFIX  ?= /usr
+EPREFIX ?=
+BINDIR  ?= $(PREFIX)/bin
+DATADIR ?= $(PREFIX)/share/push
+DESTDIR ?= 
 
 .PHONY: FORCE all install uninstall clean distclean maintainer-clean
 


### PR DESCRIPTION
In order to adapt to different operating system's standards of where to install files, or to allow local-only install, do set destination variables only if not already set. (Change `=` to `?=`, as it is also the case in [zram-init's `Makefile`](https://github.com/vaeth/zram-init/blob/main/Makefile).)